### PR TITLE
FIx compiler environment vairable name

### DIFF
--- a/oommf/config/platforms/linux-x86_64.tcl
+++ b/oommf/config/platforms/linux-x86_64.tcl
@@ -36,8 +36,8 @@ if {[catch {$config GetValue program_compiler_c++_override}] \
 }
 
 # Environment variable override for C++ compiler
-if {[info exists env(OOMMF_C++)]} {
-   $config SetValue program_compiler_c++_override $env(OOMMF_C++)
+if {[info exists env(OOMMF_CPP)]} {
+   $config SetValue program_compiler_c++_override $env(OOMMF_CPP)
 }
 
 # Support for the automated buildtest scripts


### PR DESCRIPTION
OOMMF_C++ isn't a valid environment variable key, so I changed it.