### PR TITLE
show that we can compile on OSX

### DIFF
--- a/.github/workflows/on-osx-latest.yml
+++ b/.github/workflows/on-osx-latest.yml
@@ -16,11 +16,12 @@ jobs:
 #        run: |
 #          brew update
 #          brew install gh
+      - name: how many cores in hardware
+        run: |
+          sysctl -n hw.ncpu
       - name: compile oommf
         run: |
           cat oommf-version
-          pwd
-          ls -l
           make build
       - name: run version and platform
         run: |

--- a/.github/workflows/on-osx-latest.yml
+++ b/.github/workflows/on-osx-latest.yml
@@ -12,10 +12,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-#      - name: Install GitHub CLI
-#        run: |
-#          brew update
-#          brew install gh
       - name: how many cores in hardware
         run: |
           sysctl -n hw.ncpu

--- a/.github/workflows/on-osx-latest.yml
+++ b/.github/workflows/on-osx-latest.yml
@@ -1,0 +1,32 @@
+name: on-osx-latest
+
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+#      - name: Install GitHub CLI
+#        run: |
+#          brew update
+#          brew install gh
+      - name: compile oommf
+        run: |
+          cat oommf-version
+          pwd
+          ls -l
+          make build
+      - name: run version and platform
+        run: |
+          pwd
+          tclsh oommf/oommf.tcl +version
+          tclsh oommf/oommf.tcl +platform
+      - name: run standard problem 3 directly
+        run: |
+          make test-all


### PR DESCRIPTION
branching off from upgrade-2.0a2 as the the older version of oommf doesn't seem to compile natively on OSX.