### PR TITLE
Update base image for OOMMF container on Dockerhub to supported version (Ubuntu 22.04)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Container to host OOMMF
 #
 # Takes the most recent version on https://github.com/fangohr/oommf.git
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 # Avoid asking for geographic data when installing tzdata.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Problem at
https://github.com/fangohr/oommf/actions/runs/3067085073/jobs/4952991583#step:3:36

Should be solved by moving Ubuntu 22.04 (LTS)