### PR TITLE
Github is warning online that we should move to actions v3

### DIFF
--- a/.github/workflows/in-docker-repeat-oommf-update.yml
+++ b/.github/workflows/in-docker-repeat-oommf-update.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - name: Initialisation
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Build and test inside container
       run: make -f Makefile-update-oommf in-docker-replay-oommf-update

--- a/.github/workflows/on-osx-latest.yml
+++ b/.github/workflows/on-osx-latest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: how many cores in hardware
         run: |
           sysctl -n hw.ncpu

--- a/.github/workflows/on-ubuntu-in-docker.yml
+++ b/.github/workflows/on-ubuntu-in-docker.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Initialisation
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Build and test inside container
       run: make in-docker

--- a/.github/workflows/on-ubuntu-latest.yml
+++ b/.github/workflows/on-ubuntu-latest.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Initialisation
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install dependencies
       run: sudo apt-get install -y tk-dev tcl-dev

--- a/.github/workflows/ubermag-container.yml
+++ b/.github/workflows/ubermag-container.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Initialisation
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Build OOMMF in Container from master branch
       run: cd docker && make build


### PR DESCRIPTION
It actually said:

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Some googling suggests this commit should fix
it (https://github.com/timovv/notion-website-template/pull/12)