### PR TITLE
replace Ubuntu 22.10 with Debian 12 (2023)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Container to host compilation of OOMMF in
 
-FROM ubuntu:22.04
+FROM debian:bookworm
 
 # Avoid asking for geographic data when installing tzdata.
 ENV DEBIAN_FRONTEND noninteractive

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Container to host OOMMF
 #
 # Takes the most recent version on https://github.com/fangohr/oommf.git
-FROM ubuntu:22.04
+FROM debian:bookworm
 
 # Avoid asking for geographic data when installing tzdata.
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
No significant urgency for this: Debian 12 is a bit more recent than Ubuntu 22.10, and the non-LTS editions of Ubuntu expiry soon.

MR fails because we can't compile a particular extensions (which seems independent from the underlying OS). Otherwise this should be ready to be merged.